### PR TITLE
refactor: simplify HTML rendering code to add logic for each kind of html source file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1188,9 +1188,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,18 +1199,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,12 @@ use std::path::{Path,PathBuf};
 use tracing::{error, info};
 
 #[derive(Clone, Debug)]
+pub struct Context<'a> {
+    pub config: &'a Config,
+    pub hbs: handlebars::Handlebars<'a>
+}
+
+#[derive(Clone, Debug)]
 pub struct Config {
     pub outdir: PathBuf,
     pub builddir: PathBuf,
@@ -16,7 +22,7 @@ pub struct Config {
 fn root_prefix_format(path_prefix: &str) -> String {
     if path_prefix == "" {
         String::from("/")
-    } else { 
+    } else {
         let start = if path_prefix.starts_with('/') { "" } else { "/" };
         let end = if path_prefix.ends_with('/') { "" } else { "/" };
         format!("{}{}{}", start, path_prefix, end)
@@ -36,7 +42,7 @@ impl Config {
     pub fn buildtemplatedir(&self) -> PathBuf {
          self.builddir.join("template")
     }
-    
+
     pub fn new(outdir_str: &str,
            sourcedir_str: &str,
            templatedir_str: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use anyhow;
 use tracing::info;
 
 mod config;
-use config::Config;
+use config::{Config, Context};
 mod devserve;
 mod setup;
 
@@ -28,12 +28,12 @@ struct Cli {
     #[clap(short, long, value_parser, default_value = "template")]
     templatedir: String,
 
-    /// path prefix: change if deploying somewhere that is not root path 
+    /// path prefix: change if deploying somewhere that is not root path
     #[clap(short, long, value_parser, default_value = "")]
     prefix: String,
-    
+
     #[command(subcommand)]
-    command: Option<Command>,    
+    command: Option<Command>,
 
 }
 
@@ -47,7 +47,7 @@ enum Command {
 fn cli_config(cli: &Cli) -> Config {
     Config::new(&*cli.outdir,
             &*cli.indir,
-            &*cli.templatedir, 
+            &*cli.templatedir,
             &*cli.prefix)
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,8 +10,8 @@ use walkdir::WalkDir;
 mod dir_entry;
 pub use self::dir_entry::DirEntryExt;
 
-// pub mod path;
-// pub use self::path::PathExt;
+pub mod path;
+pub use self::path::PathExt as PathExt;
 
 use crate::config::Config;
 

--- a/src/web/document.rs
+++ b/src/web/document.rs
@@ -1,0 +1,18 @@
+use new_mime_guess as mime_guess;
+use mime::Mime;
+use std::path::{Path, PathBuf};
+
+pub struct Document {
+    pub path: PathBuf,
+    pub mime: Mime
+}
+
+impl Document {
+    pub fn from_path<P: AsRef<Path>>(document_path: P) -> Self {
+        let path = document_path.as_ref();
+        Document {
+            path: PathBuf::from(path),
+            mime: mime_guess::from_path(path).first_or_octet_stream()
+        }
+    }
+}

--- a/src/web/document.rs
+++ b/src/web/document.rs
@@ -1,6 +1,6 @@
-use new_mime_guess as mime_guess;
 use mime::Mime;
 use std::path::{Path, PathBuf};
+use crate::util::PathExt;
 
 pub struct Document {
     pub path: PathBuf,
@@ -12,7 +12,12 @@ impl Document {
         let path = document_path.as_ref();
         Document {
             path: PathBuf::from(path),
-            mime: mime_guess::from_path(path).first_or_octet_stream()
+            mime: {
+                match path.mimetype() {
+                    Some(mimetype) => mimetype,
+                    None => mime::APPLICATION_OCTET_STREAM
+                }
+            }
         }
     }
 }

--- a/src/web/document.rs
+++ b/src/web/document.rs
@@ -1,5 +1,6 @@
 use mime::Mime;
 use std::path::{Path, PathBuf};
+use crate::Config;
 use crate::util::PathExt;
 
 pub struct Document {
@@ -20,4 +21,14 @@ impl Document {
             }
         }
     }
+    pub fn outpath(&self, config: &Config) -> anyhow::Result<PathBuf> {
+        let stem = config.outpath(&self.path)?;
+        let path = match self.mime.subtype().as_str() {
+            "x-handlebars-template" => stem.with_extension(""),
+            _ => stem.with_extension("html")
+
+        };
+        Ok(path)
+    }
+
 }

--- a/src/web/document.rs
+++ b/src/web/document.rs
@@ -1,8 +1,13 @@
 use mime::Mime;
+use std::fmt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use crate::Config;
-use crate::util::PathExt;
+use tracing::info;
+use crate::{Config, Context};
+use crate::web::md;
+use crate::util::*;
 
+#[derive(Debug, Clone)]
 pub struct Document {
     pub path: PathBuf,
     pub mime: Mime
@@ -31,4 +36,139 @@ impl Document {
         Ok(path)
     }
 
+    pub fn html_generator(&self, context: &Context) -> anyhow::Result<Option<HtmlGenerator>> {
+        match HtmlGenerator::from_document(context, self) {
+            Err(e) => {
+                if e.downcast_ref() == Some(&NotHtmlSourceError {})  {
+                    return Ok(None)
+                } else {
+                    anyhow::bail!(e)
+                }
+            },
+            Ok(generator) => Ok(Some(generator))
+        }
+    }
 }
+
+
+//-------------errors----------------
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotHtmlSourceError {  }  //path: String
+impl std::error::Error for NotHtmlSourceError {}
+impl fmt::Display for NotHtmlSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "not an HTML source, based on path file extension") //: {}", self.path)
+    }
+}
+pub enum HtmlGenerator {
+    Markdown(MarkdownData),
+    Template(HandlebarsTemplate)
+}
+
+impl HtmlGenerator {
+    pub fn from_document(context: &Context, document: &Document) -> anyhow::Result<Self> {
+        return match document.mime.subtype().as_str() {
+                "x-handlebars-template" => {
+                    let data = HandlebarsTemplate::from_path(context, &document.path)?;
+                    Ok(HtmlGenerator::Template(data))
+                },
+                "markdown"
+                => {
+                    let data = MarkdownData::from_path(context, &document.path)?;
+                    Ok(HtmlGenerator::Markdown(data))
+                },
+                _ => {
+                    //anyhow::bail!(NotHtmlSourceError(document.path.display().to_string()))
+                    anyhow::bail!(NotHtmlSourceError {})
+                }
+            }
+    }
+    pub fn render<W: Write>(&self, context: &Context, writer: W) -> anyhow::Result<()> {
+        match self {
+            HtmlGenerator::Markdown(generator) => generator.render(context, writer),
+            HtmlGenerator::Template(generator) => generator.render(context, writer)
+         }
+    }
+}
+//---------------
+use std::collections::HashMap;
+
+fn read_source<P: AsRef<Path>>(sourcepath: P) -> anyhow::Result<(HashMap<String, String>, String)>
+{
+    let source = read_file_to_string(sourcepath)?;
+    use matter::matter;
+    let (data, content) = match matter(&source) {
+        None => {info!("matter: None");
+            let data: HashMap<String, String> = HashMap::new();
+            (data, source)
+        },
+
+        Some((yaml_string, content)) => {
+            info!("matter:\n{:?}\n------", yaml_string);
+            let data:HashMap<String, String> = serde_yaml::from_str(&yaml_string)?;
+
+            //  let data: HashMap<&str, String> = HashMap::new();
+            (data, content)
+        }
+    };
+    Ok((data, content))
+}
+
+
+pub struct MarkdownData {
+    attr: HashMap<String, String>,
+}
+
+trait GenerateHtml {
+    fn render<W: Write>(&self, context: &Context, writer: W) -> anyhow::Result<()>;
+}
+
+impl GenerateHtml for MarkdownData {
+    fn render<W: Write>(&self, context: &Context, writer: W) -> anyhow::Result<()> {
+        context.hbs.render_to_write("default", &self.attr, writer)?;
+        Ok(())
+    }
+}
+
+impl MarkdownData {
+    fn from_path<P:AsRef<Path>>(context: &Context, path: P) -> anyhow::Result<Self> {
+        let html_body= md::file2html(path)?;
+
+        let mut template_vars = HashMap::new();
+        let site_attr = context.config.site_attr.clone();
+        template_vars.extend(site_attr);
+
+        let body_string = String::from_utf8(html_body)?;
+        template_vars.insert("body".into(), body_string);
+
+        Ok(MarkdownData {
+            attr: template_vars,
+        })
+    }
+}
+
+pub struct HandlebarsTemplate {
+    attr: HashMap<String, String>
+}
+
+impl GenerateHtml for HandlebarsTemplate {
+    fn render<W: Write>(&self, context: &Context, writer: W) -> anyhow::Result<()> {
+        context.hbs.render_to_write("default", &self.attr, writer)?;
+        Ok(())
+    }
+}
+impl HandlebarsTemplate {
+    fn from_path<P:AsRef<Path>>(context: &Context, path: P) -> anyhow::Result<Self> {
+        let (mut data, content) = read_source(path)?;
+        let site_attr = context.config.site_attr.clone();
+        data.extend(site_attr);
+        let hbs = &context.hbs;
+        let html_body: String = hbs.render_template(&content, &data)?;
+        data.insert("body".into(), html_body);
+
+        Ok(HandlebarsTemplate {
+            attr: data,
+        })
+    }
+}
+

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,24 +1,22 @@
-use anyhow::Result;
-use handlebars::Handlebars;
 use std::path::Path;
-use std::collections::HashMap;
 use tracing::{info, trace};
 use walkdir::WalkDir;
 mod document;
 use document::Document;
 
-mod md;
+pub mod md;
 pub use md::Ref as Ref;
 
 mod audio;
 
 use crate::{
-    config::Config,
+    config::Context,
     util::*,
 };
 
 
-pub fn process_files(config: &Config, handlebars: &Handlebars) -> anyhow::Result<()> {
+pub fn process_files(context: &Context) -> anyhow::Result<()> {
+    let config = context.config;
     info!("Processing files...");
     let walker = WalkDir::new(&config.sourcedir)
         .follow_links(true)
@@ -35,7 +33,7 @@ pub fn process_files(config: &Config, handlebars: &Handlebars) -> anyhow::Result
         if path.is_dir() {
             create_destdir(config, path)?;
         } else {
-            render_file(config, &handlebars, path)?;
+            render_file(context, path)?;
         }
     }
 
@@ -43,74 +41,25 @@ pub fn process_files(config: &Config, handlebars: &Handlebars) -> anyhow::Result
 }
 
 
-
-fn read_source<P: AsRef<Path>>(sourcepath: P) -> Result<(HashMap<String, String>, String)>
-{
-    let source = read_file_to_string(sourcepath)?;
-    use matter::matter;
-    let (data, content) = match matter(&source) {
-        None => {info!("matter: None");
-            let data: HashMap<String, String> = HashMap::new();
-            (data, source)
-        },
-
-        Some((yaml_string, content)) => {
-            info!("matter:\n{:?}\n------", yaml_string);
-            let data:HashMap<String, String> = serde_yaml::from_str(&yaml_string)?;
-
-            //  let data: HashMap<&str, String> = HashMap::new();
-            (data, content)
-        }
-    };
-    Ok((data, content))
-}
-
 fn render_file<P: AsRef<Path>>(
-    config: &Config,
-    hbs: &Handlebars,
+    context: &Context,
     path: P,
 ) -> anyhow::Result<()> {
+    let config = context.config;
     let sourcepath = path.as_ref();
     trace!("rendering: {}", sourcepath.display());
     let document = Document::from_path(&path);
-    match document.mime.subtype().as_str() {
-        "x-handlebars-template" => {
-            let (mut data, content) = read_source(sourcepath)?;
-            let site_attr_ref = &config.site_attr;
-            data.extend(site_attr_ref.into_iter().map(|(k, v)| (k.clone(), v.clone())));
-
-            // path for writing: w/o .hbs, rooted in output directory
+    match document.html_generator(&context)? {
+        None => { std::fs::copy(&path, config.outpath(&path)?)?;},
+        Some(html_source) => {
             let writepath = document.outpath(config)?;
             let writer = std::fs::File::options()
                 .create(true)
                 .write(true)
                 .open(writepath)?;
-            let html_body = hbs.render_template(&content, &data)?;
-            data.insert("body".into(), html_body);
-            // hbs.render_template_to_write("default", &data, writer)?;
-            hbs.render_to_write("default", &data, writer)?;
-
+            html_source.render(&context, writer)?;
         }
-        "markdown" => {
-            let html_body = md::file2html(sourcepath)?;
 
-            // path for writing: html extension, rooted in output directory
-            let writepath = document.outpath(config)?;
-            let writer = std::fs::File::options()
-                .create(true)
-                .write(true)
-                .open(writepath)?;
-
-            let mut template_vars = HashMap::new();
-            let body_string = String::from_utf8(html_body)?;
-            template_vars.insert("body", body_string);
-
-            hbs.render_to_write("default", &template_vars, writer)?;
-        },
-        _ => {
-            // copy the file
-            let _ = std::fs::copy(&path, config.outpath(&path)?);
-        }
     }
     Ok(())
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -80,7 +80,7 @@ fn render_file<P: AsRef<Path>>(
             data.extend(site_attr_ref.into_iter().map(|(k, v)| (k.clone(), v.clone())));
 
             // path for writing: w/o .hbs, rooted in output directory
-            let writepath = config.outpath(sourcepath.with_extension(""))?;
+            let writepath = document.outpath(config)?;
             let writer = std::fs::File::options()
                 .create(true)
                 .write(true)
@@ -95,7 +95,7 @@ fn render_file<P: AsRef<Path>>(
             let html_body = md::file2html(sourcepath)?;
 
             // path for writing: html extension, rooted in output directory
-            let writepath = config.outpath(sourcepath.with_extension("html"))?;
+            let writepath = document.outpath(config)?;
             let writer = std::fs::File::options()
                 .create(true)
                 .write(true)


### PR DESCRIPTION
preparing to address https://github.com/ultrasaurus/altwebgen/issues/12

there was a lot of duplicate code in markdown and handlebar template rendering into HTML, 
didn't want to make more of it!