### PR TITLE
[WIP] use words-rs branch 'mismatch-fixes' -- one test failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 [[package]]
 name = "words"
 version = "0.1.0"
-source = "git+https://github.com/ultrasaurus/words-rs.git?tag=0.1.0#30eb6e36c64977f0886e53f9086d7f3c83c22c29"
+source = "git+https://github.com/ultrasaurus/words-rs.git?branch=mismatch-fixes#f7268b73d13c68b65b13af05a1ce2351e1bc5af4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 walkdir = "2.5.0"
 warp = "0.3.6"
-words = {git = "https://github.com/ultrasaurus/words-rs.git", tag="0.1.0"}
+words = {git = "https://github.com/ultrasaurus/words-rs.git", branch="mismatch-fixes"}

--- a/src/web/md/mod.rs
+++ b/src/web/md/mod.rs
@@ -37,7 +37,7 @@ fn str2html_with_timing(source: &str, timings: &Vec<WordTime>) -> anyhow::Result
     while let Some(event) = parser.next() {
         let next_event= match event {
             Event::Text(cow_str) => {
-                let html_buf = words::html_words(cow_str, Some(timings))?;
+                let html_buf = words::html_words(&cow_str, Some(timings))?;
                 let html_string = String::from(html_buf);
                 Event::Html(html_string.into())
             },
@@ -77,7 +77,7 @@ mod tests {
         ];
        let result = str2html_with_timing("hello world", &timings).unwrap();
        let result_string = String::from_utf8(result).unwrap();
-        assert_eq!("<p><span word='0' char='0' start='0.9' end='0.1' debug_body='hello'>hello</span> <span word='1' char='6' start='0.2' end='0.3' debug_body='world'>world</span></p>\n", result_string);
+        assert_eq!("<p><span word='0' start='0.9' end='0.1' debug_body='hello'>hello</span> <span word='1' start='0.2' end='0.3' debug_body='world'>world</span></p>\n", result_string);
 
     }
 

--- a/src/web/md/ref_markdown.rs
+++ b/src/web/md/ref_markdown.rs
@@ -225,7 +225,7 @@ mod tests {
         let output_string = String::from_utf8(write_buf).unwrap();
 
         let audio_html: String = audio_tag("short-sentence.mp3",  MP3_MIME_STR, "/media/short-sentence.mp3");
-        let expected_words =   "<p><span word='0' char='0' start='0.11' end='0.17' debug_body='It'>it</span> <span word='1' char='3' start='0.211' end='0.352' debug_body='may'>may</span> <span word='2' char='7' start='0.392' end='0.755' debug_body='contain'>contain</span> <span word='3' char='15' start='0.876' end='1.622' debug_body='annotations,'>annotations</span>,<span word='4' char='28' start='2.368' end='2.832' debug_body='additions'>additions</span> <span word='5' char='38' start='2.893' end='2.973' debug_body='and'>and</span> <span word='6' char='42' start='3.034' end='3.498' debug_body='footnotes'>footnotes</span></p>";
+        let expected_words =   "<p><span word='0' start='0.11' end='0.17' debug_body='It'>it</span> <span word='1' start='0.211' end='0.352' debug_body='may'>may</span> <span word='2' start='0.392' end='0.755' debug_body='contain'>contain</span> <span word='3' start='0.876' end='1.622' debug_body='annotations,'>annotations</span>,<span word='4' start='2.368' end='2.832' debug_body='additions'>additions</span> <span word='5' start='2.893' end='2.973' debug_body='and'>and</span> <span word='6' start='3.034' end='3.498' debug_body='footnotes'>footnotes</span></p>";
         let expected = format!("{}{}", audio_html, expected_words);
         assert_eq!(output_string.trim(), expected);
     }


### PR DESCRIPTION
- updated param reference for html_words (I had forgotten that I changed the API to make more testable)
- fixed expected test data change (removing "char='..'"
- unexpected test failure: test_write_md_audio_transcript