### PR TITLE
markdown yaml front-matter creates template vars

### DIFF
--- a/samples/markdown/source/index.md
+++ b/samples/markdown/source/index.md
@@ -1,1 +1,6 @@
+---
+title: Hypertext
+---
+# Hypertext Quote
+
  Let me introduce the word "hypertext" to mean a body of written or pictorial material interconnected in such a complex way that it could not conveniently be presented or represented on paper. It may contain summaries, or maps of its contents and their interrelations; it may contain annotations, additions and footnotes from scholars who have examined it. Let me suggest that such an object and system, properly designed and administered, could have great potential for education, increasing the student's range of choices, his sense of freedom, his motivation, and his intellectual grasp. Such a system could grow indefinitely, gradually including more and more of the world's written knowledge. However, its internal file structure would have to be built to accept growth, change and complex informational arrangements.

--- a/samples/markdown/template/default.hbs
+++ b/samples/markdown/template/default.hbs
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    {{!-- <title>{{ title }}</title> --}}
+    <title>{{ title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 </head>

--- a/src/web/document.rs
+++ b/src/web/document.rs
@@ -145,13 +145,13 @@ impl GenerateHtml for MarkdownData {
 
 impl MarkdownData {
     fn from_path<P:AsRef<Path>>(context: &Context, path: P) -> anyhow::Result<Self> {
-        let html_body= md::file2html(path)?;
-
-        let mut template_vars = HashMap::new();
+        let (mut template_vars, content) = read_source(path)?;
         let site_attr = context.config.site_attr.clone();
         template_vars.extend(site_attr);
 
+        let html_body= md::str2html(&content)?;
         let body_string = String::from_utf8(html_body)?;
+
         template_vars.insert("body".into(), body_string);
 
         Ok(MarkdownData {

--- a/src/web/md/mod.rs
+++ b/src/web/md/mod.rs
@@ -12,7 +12,7 @@ pub fn file2html<P: AsRef<Path>>(sourcepath: P) -> anyhow::Result<Vec<u8>> {
     str2html(&source)
 }
 
-fn str2html(source: &str) -> anyhow::Result<Vec<u8>> {
+pub fn str2html(source: &str) -> anyhow::Result<Vec<u8>> {
     let mut html_body: Vec<u8> = Vec::new();
 
     let parser = cmark::Parser::new(&source);


### PR DESCRIPTION
for plain .md files, parse yaml front-matter and make vars available to template