### PR TITLE
render handlebar templates for markdown as well as html

### DIFF
--- a/src/test/data/var.md.hbs
+++ b/src/test/data/var.md.hbs
@@ -1,0 +1,7 @@
+---
+author: Ada Lovelace
+---
+
+Those who have learned to walk on the threshold of the unknown worlds, by means of what are commonly termed par
+excellence the exact sciences, may then, with the fair white wings of imagination, hope to soar further into the
+unexplored amidst which we live. -- {{author}}


### PR DESCRIPTION
addresses https://github.com/ultrasaurus/altwebgen/issues/32
by allowing `[linkname]({{baseurl}}/whatever)` in markdown files

this features also enables other capabilities for website developers :)