### PR TITLE
improve error output for command-line tools

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,3 +20,6 @@ pip install numpy==1.26.3
 which whisperx
 
 whisperx --help
+
+# make it so we can easily find transcript-converter python script
+ln -s $PWD/transcript-converter $HOME/transcript-converter


### PR DESCRIPTION
more readable error for : https://github.com/ultrasaurus/altwebgen/issues/36

now reports
```
whisperx successfully exited with status code (0)
convert_to_transcript_json in: ref/as-we-may-think-6.json out:ref/as-we-may-think-6.transcript.json
transcriptConverter stdout:



transcriptConverter stderr:
Traceback (most recent call last):
  File "/Users/sallen/transcript-converter/transcriptConverter.py", line 36, in <module>
    main(input_file_path, output_file_path)
  File "/Users/sallen/transcript-converter/transcriptConverter.py", line 22, in main
    output_json = convert_to_standard_format(input_json)
  File "/Users/sallen/transcript-converter/transcriptConverter.py", line 10, in convert_to_standard_format
    "startTime": word["start"],
KeyError: 'start'



transcriptConverter exited with status code: 1
Error: setting up templates failed

Caused by:
    transcriptConverter failed with status code:1
```
