### PR TITLE
add handlebars helper 'split'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Supports
 * handlebar templates
   * for raw html (`.html.hbs`)
   * markdown (`.md.html`)
+  * in addition to built-in templates:
+    * split string (optional separator, default: '\n')
 * directly serves all other files
 * dev mode for live reload: watches file system every second, reloads page on changes
 
@@ -19,7 +21,6 @@ RUST_LOG=debug cargo run
 NOTE: everything will change, don't depend on this staying as is
 
 BEWARE:
-* live reload only works when JS code is manually included (see sidebar/templates/layout.hbs)
 * to use automatic transcript generations (and run the tests)...
 ```ln -s $PWD/transcript-converter ~/transcript-converter```
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use handlebars::Handlebars;
+use handlebars::{Handlebars,handlebars_helper};
 use tracing::info;
 
 use crate::{
@@ -7,6 +7,11 @@ use crate::{
     util::*,
     web,
 };
+
+
+handlebars_helper!(split: |input:String, {sep:str="\n"}|
+        input.split(sep).collect::<Vec<&str>>()
+);
 
 
 pub fn init_templates<'a>(config: &'a Config) -> anyhow::Result<Context<'a>> {
@@ -24,6 +29,7 @@ pub fn init_templates<'a>(config: &'a Config) -> anyhow::Result<Context<'a>> {
     let buildtemplatedir = config.buildtemplatedir();
     info!("buildtemplatedir: {}", buildtemplatedir.display());
     let mut hbs = Handlebars::new();
+    hbs.register_helper("split", Box::new(split));
     hbs.register_templates_directory(&buildtemplatedir, Default::default())
         .map_err(|_| {
             anyhow!("failed to register template directory: {}", buildtemplatedir.display())


### PR DESCRIPTION
create additional handlebars helper 'split'
update README with new functionality
remove obsolete warning about live reload requiring custom javascript